### PR TITLE
Remove discord token

### DIFF
--- a/.env.fish
+++ b/.env.fish
@@ -1,1 +1,0 @@
-set -x TOKEN "NDk2MTQwMTQyNjg4NDY4OTky.DpMSqw.TnVSZYciox5oPXnuYVjjM2S0y_k"


### PR DESCRIPTION
The bot token is present in the `.env.fish` file.